### PR TITLE
Draft: introduce a warning for Arms without any Solids

### DIFF
--- a/Script.cs
+++ b/Script.cs
@@ -719,6 +719,21 @@ class Hardware{
     nPoseUTD = false;
     dPoseUTD = false;
   }
+  public bool HasAnySolid( ){
+    if ( this is Solid ){
+        return true;
+    }
+    if ( this is Addition ){
+        var a = this as Addition;
+        return a.H1.HasAnySolid() || a.H2.HasAnySolid();
+    }
+    if ( this is Multiplication ){
+        var m = this as Multiplication;
+        return m.H1.HasAnySolid() || m.H2.HasAnySolid();
+    }
+	return false;
+  }
+
   // << ---- P R I V A T E   V A R I A B L E S ---- >>
   // Pose control variables
   cPose  pose = new cPose(), npose = new cPose(), dpose = new cPose();
@@ -1954,13 +1969,18 @@ class UserControl : Controller{
       MyLog( "ReferenceFrame set to Arm" );
       this.ReferenceFrame = this.Arm;
     }
+    if ( !this.Arm.HasAnySolid() ) {
+      MyLog( "<<Warning>> Your Arm has no Solids and may not work as expected.");
+      MyLog( "<<Warning>> Remember: MArmOS joints don't account for blocks' physical shapes.");
+      WarningFlag = GlobStep+200;
+    }
     this.YawSpeed = YawSpeed;
     this.PitchSpeed = PitchSpeed;
     this.RollSpeed = RollSpeed;
     this.ContrStep = 0;
     this.UseTarget = false;
     this.ConstantMovement = new cPose();
-  }
+ }
 
   // << ---- P U B L I C   V A R I A B L E S ---- >>
   public bool  OnOff;


### PR DESCRIPTION
I have on at least three different occasions returned to using MArmOS after a significant time and made [this exact mistake](https://steamcommunity.com/workshop/filedetails/discussion/767595187/3046108212603853835/). That is, I've forgotten that Rotors, Hinges, and Pistons do not account for their block's physical size, just like [Kyr](https://steamcommunity.com/id/kyrinth).

This PR introduces a check for any Solids in the Arm at all, issuing a warning if none are found.

This PR is only a draft meant to get feedback from you on the idea - I haven't even tried compiling it yet. Let me know if this is something you're interesting in.

I've added the check to the UserControl constructor, but perhaps you would prefer it elsewhere. I've used a recursive method on the Hardware class, but maybe you'd rather add a method to the interface. And so on...

Thanks for the great script! Looking forward to your response.